### PR TITLE
Text and link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# Hackarto.vl
+# Hackarto.VL
 
 Website for the VL edition of the most amazing contest in CARTO. This website has been created thanks to the @design team (using [hangar-alpha](https://github.com/CartoDB/hangar-alpha/) too) and using [Atlas Hugo template](https://github.com/indigotree/atlas).
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "/"
 languageCode = "en-US"
-title = "HaCkARTO.vl"
+title = "HaCkARTO.VL"
 siteURL = "http://cartodb.github.io/hackarto.vl/"
 
 disableKinds = ["RSS"]

--- a/layouts/partials/site/documentation.html
+++ b/layouts/partials/site/documentation.html
@@ -5,10 +5,10 @@
 		</div>
 		<div class="section documentation-content grid-cell grid-cell--col6 grid-cell--col12--mobile">
 			<h4 class="title is-regular is-body u-vspace--8">documentation</h4>
-			<h2 class="title is-title">CARTO.vl</h2>
+			<h2 class="title is-title">CARTO VL</h2>
 			<p class="text is-body u-tspace--32">We have created the most amazing documentation that we could do.</p>
 			<p class="text is-body u-tspace--16">Please take a look and enjoy, obviously if you find any bugs or you have some feedback, ping us :)</p>
-			<a href="https://github.com/CartoDB/carto-vl" class="button button--medium is-baseGreyOutline u-tspace--64">
+			<a href="https://carto.com/developers/carto-vl/" class="button button--medium is-baseGreyOutline u-tspace--64">
 				<span>go to documentation</span>
 			</a>
 		</div>

--- a/layouts/partials/site/jury.html
+++ b/layouts/partials/site/jury.html
@@ -24,7 +24,7 @@
 				<li class="jury-listItem">
 					{{ partial "svg/people/rochoa.html" . }}
 					<p class="title is-subtitle">Raúl Ochoa</p>
-					<p class="text is-small">Best CARTO.vl feedback</p>
+					<p class="text is-small">Best CARTO VL feedback</p>
 				</li>
 				<li class="jury-listItem">
 					{{ partial "svg/people/ashley.html" . }}

--- a/layouts/partials/site/rules.html
+++ b/layouts/partials/site/rules.html
@@ -4,7 +4,7 @@
 		<h2 class="title is-display">Everybody can participate!!!</h2>
 		<ul class="rules-list text is-body u-tspace--32">
 			<li class="u-vspace--8">– &nbsp;1-3 people per team, and there can only be one member of the Frontend team per group.</li>
-			<li class="u-vspace--8">– &nbsp;Create a fantastic map using the new CARTO.vl library.</li>
+			<li class="u-vspace--8">– &nbsp;Create a fantastic map using the new CARTO VL library.</li>
 			<li class="u-vspace--8">– &nbsp;You have 24 hours to complete it.</li>
 		</ul>
 	</div>

--- a/layouts/partials/site/support.html
+++ b/layouts/partials/site/support.html
@@ -3,10 +3,10 @@
 		<div class="grid-cell--col8">
 			<h4 class="title is-regular is-body u-vspace--8">support</h4>
 			<h2 class="title is-title">Do you need any help?</h2>
-			<p class="text is-body u-tspace--32">We are sure that David M., Iago and Jesús A. will help you with anything you may need.</p>
+			<p class="text is-body u-tspace--32">Anyone on the CARTO VL development team will help you with anything you may need.</p>
 			<a href="https://cartoteam.slack.com/messages/CAR6XV6CC/convo/C029Y1F57-1526482170.000608/" target="_blank" class="buttonLink is-jade u-tspace--64">
 				{{ partial "svg/arrow-link.html" . }}
-		  	Join our Slack channel
+		  	Join the #hackarto-vl Slack channel
 		  </a>
 		</div>
 	</div>


### PR DESCRIPTION
- CARTO VL should be always typed in uppercase and separated by a space and not a dash or period (except on URLs) 
- Changed the documentation link to our Dev Center instead of the repository 
- A few text changes to the support section